### PR TITLE
Reset all the stored values from previous sessions

### DIFF
--- a/source/WPRIMEBALView.mc
+++ b/source/WPRIMEBALView.mc
@@ -160,6 +160,18 @@ class WPRIMEBALView extends Ui.SimpleDataField {
 			elapsedSec++;
 		}
 		else {
+			// Need to reset all the values from previous activities
+			elapsedSec = 0;
+			I = 0;
+			// If the formula is differential, initial value of w'bal is WPRIME.
+			wprimebal = 0;
+			if (FORMULA == 1) {
+				wprimebal = WPRIME;
+			}
+			wprimebalpc = 100;
+			totalBelowCP = 0;
+			countBelowCP = 0;
+
 			// Initial display, before the the session is started
 			return CP + "|" + WPRIME;
 			Sys.println("Elapsed time: " + info.elapsedTime);


### PR DESCRIPTION
Sometimes I see: "inf" or "NaN" on the screen.
Sometimes I see less than 100% at the beginning of the activity.
I assume it is caused by not destroying the object after the Activity is completed and still stores all the data from all previous Activities that lead to a buffer overflow.

It is supposed to reset all the variables before a new Activity is started.

Can you please accept the pull request and update the application on Garmin Store.
Thanks a lot.